### PR TITLE
Backfill missing lab metadata (2 files)

### DIFF
--- a/Instructions/01-foundation-model.md
+++ b/Instructions/01-foundation-model.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Explore foundation models in the model catalog of Azure Machine Learning'
+  title: Explore foundation models in the model catalog of Azure Machine Learning
+  description: Large Language Models (LLMs) used for Natural Language Processing (NLP)
+    can be costly to train. To save time and effort, you can use open source models
+    that are pre-trained on a large corpus of text. Many open source LLMs are available
+    as foundation models in the model catalog of Azure Machine Learning.
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Explore foundation models in the model catalog of Azure Machine Learning

--- a/Instructions/04-finetune-model.md
+++ b/Instructions/04-finetune-model.md
@@ -1,6 +1,17 @@
 ---
 lab:
-    title: 'Fine-tune a foundation model in the Azure Machine Learning studio'
+  title: Fine-tune a foundation model in the Azure Machine Learning studio
+  description: When you want to improve a model that processes natural language, you
+    may try to fine-tune a foundation model. A foundation model is already pre-trained
+    on a large corpus of text, meaning you'll spend considerably less time fine-tuning
+    the model to accommodate your needs than when you would train a completely new
+    model from scratch.
+  duration: 10 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Fine-tune a foundation model in the Azure Machine Learning studio


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 2

- `Instructions/01-foundation-model.md` (description,duration,level,islab,primarytopics)
- `Instructions/04-finetune-model.md` (description,duration,level,islab,primarytopics)
