### PR TITLE
Backfill missing lab metadata (2 files)

### DIFF
--- a/Instructions/01-foundation-model.md
+++ b/Instructions/01-foundation-model.md
@@ -1,6 +1,13 @@
 ---
 lab:
-    title: 'Explore foundation models in the model catalog of Azure Machine Learning'
+  title: Explore foundation models in the model catalog of Azure Machine Learning
+  description: In this exercise you'll explore the available foundation models in Azure Machine Learning's model catalog. You'll review model cards and their test results to evaluate which model best fits your needs.
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Machine Learning
 ---
 
 # Explore foundation models in the model catalog of Azure Machine Learning

--- a/Instructions/04-finetune-model.md
+++ b/Instructions/04-finetune-model.md
@@ -1,6 +1,13 @@
 ---
 lab:
-    title: 'Fine-tune a foundation model in the Azure Machine Learning studio'
+  title: Fine-tune a foundation model in the Azure Machine Learning studio
+  description: In this exercise you'll choose a foundation model from Azure Machine Learning's model catalog. You'll use a small dataset to fine-tune the model and you'll deploy the model to an endpoint. Finally, you can test your deployed model by sending new data to the endpoint.
+  duration: 10 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Machine Learning
 ---
 
 # Fine-tune a foundation model in the Azure Machine Learning studio


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 2

- `Instructions/01-foundation-model.md` (description,duration,level,islab,primarytopics)
- `Instructions/04-finetune-model.md` (description,duration,level,islab,primarytopics)
